### PR TITLE
fix missing GAS_CURRENCY

### DIFF
--- a/cryptocoins/coins/trx/tron.py
+++ b/cryptocoins/coins/trx/tron.py
@@ -216,6 +216,7 @@ tron_manager = TronManager(tron_client)
 @register_evm_handler
 class TronHandler(BaseEVMCoinHandler):
     CURRENCY = TRX_CURRENCY
+    GAS_CURRENCY = settings.TRX_NET_FEE
     COIN_MANAGER = tron_manager
     TOKEN_CURRENCIES = tron_manager.registered_token_currencies
     TOKEN_CONTRACT_ADDRESSES = tron_manager.registered_token_addresses


### PR DESCRIPTION
This fixes a missing attribute in tron handler so that tron withdrawals can occur.